### PR TITLE
Improve dev auth and add socket tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +28,8 @@
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.4.0",
+    "socket.io-client": "^4.8.1"
   }
 }

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,0 +1,86 @@
+import jwt from "jsonwebtoken";
+
+const EXTENSION_SECRET = process.env.TWITCH_EXTENSION_SECRET as string;
+const CLIENT_ID = process.env.TWITCH_CLIENT_ID as string;
+
+if (!EXTENSION_SECRET && process.env.NODE_ENV === "production") {
+  throw new Error("Missing TWITCH_EXTENSION_SECRET env variable");
+}
+
+export interface ViewerAuth {
+  id: string; // twitch user id if available or opaque id
+  displayName: string;
+  profileImageUrl?: string;
+  opaqueId: string;
+}
+
+export async function authenticateViewer(token: string): Promise<ViewerAuth> {
+  if (process.env.NODE_ENV !== "production") {
+    return {
+      id: token,
+      displayName: `dev_${token}`,
+      opaqueId: token,
+    };
+  }
+
+  const payload = jwt.verify(token, EXTENSION_SECRET) as any;
+  const opaqueId = payload.opaque_user_id as string;
+  const userId: string | undefined = payload.user_id;
+
+  if (!opaqueId) {
+    throw new Error("Invalid viewer token");
+  }
+
+  let displayName = "Anonyme";
+  let profileImageUrl: string | undefined;
+
+  if (userId) {
+    try {
+      const r = await fetch(`https://api.twitch.tv/helix/users?id=${userId}`, {
+        headers: {
+          "Client-ID": CLIENT_ID,
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (r.ok) {
+        const data = await r.json();
+        const info = data.data?.[0];
+        if (info) {
+          displayName = info.display_name;
+          profileImageUrl = info.profile_image_url;
+        }
+      }
+    } catch {
+      // ignore fetch errors, keep anonymous display
+    }
+  }
+
+  return {
+    id: userId ?? opaqueId,
+    displayName,
+    profileImageUrl,
+    opaqueId,
+  };
+}
+
+export interface StreamerAuth {
+  userId: string;
+}
+
+export async function authenticateStreamer(accessToken: string): Promise<StreamerAuth> {
+  if (process.env.NODE_ENV !== "production") {
+    return { userId: accessToken };
+  }
+  const r = await fetch("https://id.twitch.tv/oauth2/validate", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!r.ok) {
+    throw new Error("Invalid Twitch OAuth token");
+  }
+
+  const data = await r.json();
+  return { userId: data.user_id };
+}

--- a/server/src/lobbyManager.ts
+++ b/server/src/lobbyManager.ts
@@ -1,0 +1,162 @@
+import { prisma } from "./lib/prisma";
+import { DEFAULT_MAX_PLAYERS } from "@wizzy/shared";
+import {
+  LobbyConfig,
+  LobbyState,
+  ViewerInLobby,
+  QuizWithQuestions,
+  QuizEndResult,
+} from "./types";
+import { randomUUID } from "crypto";
+
+class LobbyManager {
+  private lobbies = new Map<string, LobbyState>();
+
+  async createLobby(
+    hostId: string,
+    quizId: string,
+    config?: Partial<LobbyConfig>
+  ): Promise<LobbyState> {
+    const quiz = await prisma.quiz.findFirst({
+      where: { id: quizId, owner: { twitchId: hostId } },
+      include: {
+        questions: {
+          include: { choices: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+    if (!quiz) {
+      throw new Error("Quiz not found or not owned by streamer");
+    }
+
+    const lobbyId = randomUUID();
+    const lobby: LobbyState = {
+      id: lobbyId,
+      hostId,
+      quiz: quiz as QuizWithQuestions,
+      config: { maxPlayers: config?.maxPlayers ?? DEFAULT_MAX_PLAYERS },
+      viewers: new Map(),
+      currentQuestion: -1,
+      answers: new Map(),
+    };
+    this.lobbies.set(lobbyId, lobby);
+    return lobby;
+  }
+
+  getLobby(id: string): LobbyState | undefined {
+    return this.lobbies.get(id);
+  }
+
+  removeLobby(id: string) {
+    this.lobbies.delete(id);
+  }
+
+  joinLobby(lobbyId: string, viewer: ViewerInLobby) {
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) throw new Error("Lobby not found");
+    lobby.viewers.set(viewer.id, viewer);
+  }
+
+  removeViewer(lobbyId: string, viewerId: string) {
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) return;
+    lobby.viewers.delete(viewerId);
+    if (lobby.viewers.size === 0 && lobby.currentQuestion === -1) {
+      // optional cleanup
+    }
+  }
+
+  startQuestion(lobbyId: string) {
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) throw new Error("Lobby not found");
+
+    lobby.currentQuestion++;
+    const q = lobby.quiz.questions[lobby.currentQuestion];
+    if (!q) throw new Error("No more questions");
+    lobby.answers.set(q.id, new Map());
+    return q;
+  }
+
+  submitAnswer(lobbyId: string, viewerId: string, choiceIndex: number) {
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) throw new Error("Lobby not found");
+    const question = lobby.quiz.questions[lobby.currentQuestion];
+    if (!question) throw new Error("Question not started");
+    const aMap = lobby.answers.get(question.id);
+    if (!aMap) throw new Error("Question state missing");
+    aMap.set(viewerId, choiceIndex);
+  }
+
+  revealAnswer(lobbyId: string) {
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) throw new Error("Lobby not found");
+    const question = lobby.quiz.questions[lobby.currentQuestion];
+    if (!question) throw new Error("Question not started");
+    const aMap = lobby.answers.get(question.id) || new Map();
+
+    const stats = new Map<number, number>();
+    for (const choiceIdx of aMap.values()) {
+      stats.set(choiceIdx, (stats.get(choiceIdx) || 0) + 1);
+    }
+
+    return { correct: question.correctChoice, stats };
+  }
+
+  async endQuiz(lobbyId: string): Promise<QuizEndResult[]> {
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) throw new Error("Lobby not found");
+
+    const results: QuizEndResult[] = [];
+
+    for (const viewer of lobby.viewers.values()) {
+      const viewerRecord = await prisma.viewer.upsert({
+        where: { twitchUserId: viewer.id },
+        update: { displayName: viewer.displayName },
+        create: { twitchUserId: viewer.id, displayName: viewer.displayName },
+      });
+
+      const answerCreates = lobby.quiz.questions.map((q) => {
+        const map = lobby.answers.get(q.id);
+        const idx = map?.get(viewer.id);
+        const isCorrect = idx === q.correctChoice;
+        return { questionId: q.id, selectedIdx: idx ?? -1, isCorrect };
+      });
+
+      const score = answerCreates.filter((a) => a.isCorrect).length;
+
+      await prisma.quizResult.create({
+        data: {
+          quizId: lobby.quiz.id,
+          viewerId: viewerRecord.id,
+          score,
+          answers: { create: answerCreates },
+        },
+      });
+
+      results.push({ viewerId: viewer.id, score });
+    }
+
+    this.lobbies.delete(lobbyId);
+    return results;
+  }
+
+  removeLobbiesByHost(hostId: string) {
+    for (const [id, lobby] of this.lobbies) {
+      if (lobby.hostId === hostId) {
+        this.lobbies.delete(id);
+      }
+    }
+  }
+
+  removeViewerEverywhere(viewerId: string) {
+    for (const lobby of this.lobbies.values()) {
+      if (lobby.viewers.has(viewerId)) {
+        lobby.viewers.delete(viewerId);
+      }
+    }
+  }
+}
+
+export const lobbyManager = new LobbyManager();
+export type { LobbyState } from "./types";

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -1,0 +1,115 @@
+import { Server as SocketIOServer, Socket } from "socket.io";
+import { authenticateStreamer, authenticateViewer } from "./auth";
+import { lobbyManager } from "./lobbyManager";
+import { ViewerInLobby } from "./types";
+
+export function initSocket(io: SocketIOServer) {
+  io.use(async (socket, next) => {
+    try {
+      const role = socket.handshake.auth?.role as string | undefined;
+      if (role === "streamer") {
+        const accessToken = socket.handshake.auth?.accessToken;
+        const auth = await authenticateStreamer(accessToken);
+        socket.data.userId = auth.userId;
+        socket.data.role = "streamer";
+      } else {
+        const token = socket.handshake.auth?.token;
+        const auth = await authenticateViewer(token);
+        socket.data.userId = auth.id;
+        socket.data.role = "viewer";
+        socket.data.viewerInfo = auth;
+      }
+      next();
+    } catch (err) {
+      next(err instanceof Error ? err : new Error("Auth failed"));
+    }
+  });
+
+  io.on("connection", (socket: Socket) => {
+    const role = socket.data.role as string;
+    if (role === "streamer") {
+      handleStreamer(io, socket);
+    } else {
+      handleViewer(io, socket);
+    }
+  });
+}
+
+function handleStreamer(io: SocketIOServer, socket: Socket) {
+  const userId = socket.data.userId as string;
+
+  socket.on("create_lobby", async (payload: { quizId: string; config?: { maxPlayers?: number } }) => {
+    try {
+      const lobby = await lobbyManager.createLobby(userId, payload.quizId, payload.config);
+      socket.join(lobby.id);
+      socket.emit("lobby_created", { lobbyId: lobby.id });
+    } catch (err) {
+      socket.emit("error", { message: (err as Error).message });
+    }
+  });
+
+  socket.on("start_question", async (payload: { lobbyId: string }) => {
+    try {
+      const q = lobbyManager.startQuestion(payload.lobbyId);
+      io.to(payload.lobbyId).emit("question_started", {
+        id: q.id,
+        text: q.text,
+        choices: q.choices.map((c) => ({ index: c.index, text: c.text })),
+        audioPromptKey: q.audioPromptKey,
+      });
+    } catch (err) {
+      socket.emit("error", { message: (err as Error).message });
+    }
+  });
+
+  socket.on("reveal_answer", (payload: { lobbyId: string }) => {
+    try {
+      const result = lobbyManager.revealAnswer(payload.lobbyId);
+      io.to(payload.lobbyId).emit("answer_reveal", {
+        correct: result.correct,
+        stats: Array.from(result.stats.entries()),
+      });
+    } catch (err) {
+      socket.emit("error", { message: (err as Error).message });
+    }
+  });
+
+  socket.on("end_quiz", async (payload: { lobbyId: string }) => {
+    try {
+      const results = await lobbyManager.endQuiz(payload.lobbyId);
+      io.to(payload.lobbyId).emit("quiz_ended", { results });
+    } catch (err) {
+      socket.emit("error", { message: (err as Error).message });
+    }
+  });
+
+  socket.on("disconnect", () => {
+    lobbyManager.removeLobbiesByHost(userId);
+  });
+}
+
+function handleViewer(io: SocketIOServer, socket: Socket) {
+  const auth = socket.data.viewerInfo as ViewerInLobby;
+
+  socket.on("join_lobby", (payload: { lobbyId: string }) => {
+    try {
+      lobbyManager.joinLobby(payload.lobbyId, { ...auth, socketId: socket.id });
+      socket.join(payload.lobbyId);
+      socket.emit("lobby_joined", { lobbyId: payload.lobbyId });
+    } catch (err) {
+      socket.emit("error", { message: (err as Error).message });
+    }
+  });
+
+  socket.on("submit_answer", (payload: { lobbyId: string; choiceIndex: number }) => {
+    try {
+      lobbyManager.submitAnswer(payload.lobbyId, auth.id, payload.choiceIndex);
+    } catch (err) {
+      socket.emit("error", { message: (err as Error).message });
+    }
+  });
+
+  socket.on("disconnect", () => {
+    lobbyManager.removeViewerEverywhere(auth.id);
+  });
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,35 @@
+import type { Prisma } from "@wizzy/prisma";
+
+export type QuizWithQuestions = Prisma.QuizGetPayload<{
+  include: {
+    questions: {
+      include: { choices: true };
+    };
+  };
+}>;
+
+export interface ViewerInLobby {
+  id: string;
+  displayName: string;
+  imageUrl?: string;
+  socketId: string;
+}
+
+export interface LobbyConfig {
+  maxPlayers: number;
+}
+
+export interface LobbyState {
+  id: string;
+  hostId: string;
+  quiz: QuizWithQuestions;
+  config: LobbyConfig;
+  viewers: Map<string, ViewerInLobby>;
+  currentQuestion: number;
+  answers: Map<string, Map<string, number>>;
+}
+
+export interface QuizEndResult {
+  viewerId: string;
+  score: number;
+}

--- a/server/test/server.test.ts
+++ b/server/test/server.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { io as Client } from 'socket.io-client';
+import { AddressInfo } from 'net';
+import { createApp } from '../src/index';
+import { lobbyManager } from '../src/lobbyManager';
+
+vi.mock('../src/lib/prisma', () => {
+  const quiz = {
+    id: 'quiz1',
+    questions: [
+      {
+        id: 'q1',
+        text: 'Q1',
+        choices: [
+          { id: 'c1', text: 'A', index: 0 },
+          { id: 'c2', text: 'B', index: 1 },
+        ],
+        correctChoice: 0,
+        order: 0,
+      },
+    ],
+  };
+  return {
+    prisma: {
+      quiz: {
+        findFirst: vi.fn().mockResolvedValue(quiz),
+      },
+      viewer: {
+        upsert: vi.fn().mockResolvedValue({ id: 'v', twitchUserId: 'v' }),
+      },
+      quizResult: {
+        create: vi.fn(),
+      },
+    },
+  };
+});
+
+const testEnv = { NODE_ENV: 'development' };
+
+describe('socket server', () => {
+  let httpServer: ReturnType<typeof createApp>['httpServer'];
+  let port: number;
+
+  beforeEach(async () => {
+    process.env = { ...process.env, ...testEnv };
+    const app = createApp();
+    httpServer = app.httpServer;
+    await new Promise((res) => httpServer.listen(0, res));
+    port = (httpServer.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    httpServer.close();
+    lobbyManager['lobbies'].clear();
+  });
+
+  it('runs full quiz flow', async () => {
+    const streamer = Client(`http://localhost:${port}`, { auth: { role: 'streamer', accessToken: 's1' } });
+    const sCreated = new Promise<{ lobbyId: string }>((resolve) => streamer.on('lobby_created', resolve));
+    streamer.emit('create_lobby', { quizId: 'quiz1' });
+    const { lobbyId } = await sCreated;
+
+    const viewer1 = Client(`http://localhost:${port}`, { auth: { role: 'viewer', token: 'v1' } });
+    const viewer2 = Client(`http://localhost:${port}`, { auth: { role: 'viewer', token: 'v2' } });
+
+    const join1 = new Promise((r) => viewer1.on('lobby_joined', r));
+    const join2 = new Promise((r) => viewer2.on('lobby_joined', r));
+    viewer1.emit('join_lobby', { lobbyId });
+    viewer2.emit('join_lobby', { lobbyId });
+    await join1;
+    await join2;
+
+    expect(lobbyManager.getLobby(lobbyId)?.viewers.size).toBe(2);
+
+    const qStarted = new Promise((r) => streamer.on('question_started', r));
+    streamer.emit('start_question', { lobbyId });
+    await qStarted;
+
+    viewer1.emit('submit_answer', { lobbyId, choiceIndex: 0 });
+    viewer2.emit('submit_answer', { lobbyId, choiceIndex: 1 });
+
+    const reveal = new Promise<{ correct: number; stats: [number, number][] }>((r) => streamer.on('answer_reveal', r));
+    streamer.emit('reveal_answer', { lobbyId });
+    const stats = await reveal;
+    expect(stats.correct).toBe(0);
+
+    viewer2.close();
+    await new Promise((f) => setTimeout(f, 50));
+    expect(lobbyManager.getLobby(lobbyId)?.viewers.size).toBe(1);
+
+    const ended = new Promise<{ results: any[] }>((r) => streamer.on('quiz_ended', r));
+    streamer.emit('end_quiz', { lobbyId });
+    const res = await ended;
+    expect(res.results.length).toBe(1);
+
+    streamer.close();
+  });
+});

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json && cp -r src/prisma dist/prisma"
   },
   "devDependencies": {
     "@types/node": "^24.0.3",


### PR DESCRIPTION
## Summary
- allow any token for dev mode in Twitch auth
- expose server creation helper for tests
- add vitest config and socket test covering quiz flow
- update server scripts and dev deps for test support

## Testing
- `pnpm build:shared`
- `pnpm --filter server run build`
- `pnpm --filter server run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8de007b08323911bb2da7a3e5d53