### PR TITLE
Implement per-question scoring workflow

### DIFF
--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -1,7 +1,23 @@
 import { Server as SocketIOServer, Socket } from "socket.io";
 import { authenticateStreamer, authenticateViewer } from "./auth";
 import { lobbyManager } from "./lobbyManager";
-import { ViewerInLobby } from "./types";
+import { ViewerInLobby, LobbyState } from "./types";
+import {
+  CreateLobbyPayload,
+  LobbyCreatedPayload,
+  JoinLobbyPayload,
+  LobbyJoinedPayload,
+  StartQuestionPayload,
+  QuestionStartedPayload,
+  SubmitAnswerPayload,
+  AnswerRevealPayload,
+  QuestionRecapPayload,
+  ScoreUpdatePayload,
+  EndQuizPayload,
+  QuizEndedPayload,
+  ErrorPayload,
+  ScoreEntry,
+} from "@wizzy/shared";
 
 export function initSocket(io: SocketIOServer) {
   io.use(async (socket, next) => {
@@ -38,48 +54,67 @@ export function initSocket(io: SocketIOServer) {
 function handleStreamer(io: SocketIOServer, socket: Socket) {
   const userId = socket.data.userId as string;
 
-  socket.on("create_lobby", async (payload: { quizId: string; config?: { maxPlayers?: number } }) => {
+  socket.on(
+    "create_lobby",
+    async (payload: CreateLobbyPayload) => {
     try {
-      const lobby = await lobbyManager.createLobby(userId, payload.quizId, payload.config);
+      const lobby = await lobbyManager.createLobby(
+        userId,
+        socket.id,
+        payload.quizId,
+        payload.config
+      );
       socket.join(lobby.id);
-      socket.emit("lobby_created", { lobbyId: lobby.id });
+      const msg: LobbyCreatedPayload = { lobbyId: lobby.id };
+      socket.emit("lobby_created", msg);
     } catch (err) {
-      socket.emit("error", { message: (err as Error).message });
+      const errMsg: ErrorPayload = { message: (err as Error).message };
+      socket.emit("error", errMsg);
     }
-  });
+  }
+  );
 
-  socket.on("start_question", async (payload: { lobbyId: string }) => {
+  socket.on("start_question", async (payload: StartQuestionPayload) => {
     try {
       const q = lobbyManager.startQuestion(payload.lobbyId);
-      io.to(payload.lobbyId).emit("question_started", {
+      const lobby = lobbyManager.getLobby(payload.lobbyId)!;
+      const qMsg: QuestionStartedPayload = {
         id: q.id,
         text: q.text,
         choices: q.choices.map((c) => ({ index: c.index, text: c.text })),
         audioPromptKey: q.audioPromptKey,
-      });
+      };
+      io.to(payload.lobbyId).emit("question_started", qMsg);
+
+      lobby.questionTimer = setTimeout(() => {
+        const result = lobbyManager.revealAnswer(payload.lobbyId);
+        broadcastQuestionResults(io, lobby, result);
+      }, lobby.config.questionDuration * 1000);
     } catch (err) {
-      socket.emit("error", { message: (err as Error).message });
+      const errMsg: ErrorPayload = { message: (err as Error).message };
+      socket.emit("error", errMsg);
     }
   });
 
-  socket.on("reveal_answer", (payload: { lobbyId: string }) => {
+  socket.on("reveal_answer", (payload: StartQuestionPayload) => {
     try {
+      const lobby = lobbyManager.getLobby(payload.lobbyId)!;
       const result = lobbyManager.revealAnswer(payload.lobbyId);
-      io.to(payload.lobbyId).emit("answer_reveal", {
-        correct: result.correct,
-        stats: Array.from(result.stats.entries()),
-      });
+      broadcastQuestionResults(io, lobby, result);
     } catch (err) {
-      socket.emit("error", { message: (err as Error).message });
+      const errMsg: ErrorPayload = { message: (err as Error).message };
+      socket.emit("error", errMsg);
     }
   });
 
-  socket.on("end_quiz", async (payload: { lobbyId: string }) => {
+  socket.on("end_quiz", async (payload: EndQuizPayload) => {
     try {
       const results = await lobbyManager.endQuiz(payload.lobbyId);
-      io.to(payload.lobbyId).emit("quiz_ended", { results });
+      const msg: QuizEndedPayload = { results };
+      io.to(payload.lobbyId).emit("quiz_ended", msg);
     } catch (err) {
-      socket.emit("error", { message: (err as Error).message });
+      const errMsg: ErrorPayload = { message: (err as Error).message };
+      socket.emit("error", errMsg);
     }
   });
 
@@ -91,25 +126,63 @@ function handleStreamer(io: SocketIOServer, socket: Socket) {
 function handleViewer(io: SocketIOServer, socket: Socket) {
   const auth = socket.data.viewerInfo as ViewerInLobby;
 
-  socket.on("join_lobby", (payload: { lobbyId: string }) => {
+  socket.on("join_lobby", (payload: JoinLobbyPayload) => {
     try {
       lobbyManager.joinLobby(payload.lobbyId, { ...auth, socketId: socket.id });
       socket.join(payload.lobbyId);
-      socket.emit("lobby_joined", { lobbyId: payload.lobbyId });
+      const msg: LobbyJoinedPayload = { lobbyId: payload.lobbyId };
+      socket.emit("lobby_joined", msg);
     } catch (err) {
-      socket.emit("error", { message: (err as Error).message });
+      const errMsg: ErrorPayload = { message: (err as Error).message };
+      socket.emit("error", errMsg);
     }
   });
 
-  socket.on("submit_answer", (payload: { lobbyId: string; choiceIndex: number }) => {
+  socket.on("submit_answer", (payload: SubmitAnswerPayload) => {
     try {
       lobbyManager.submitAnswer(payload.lobbyId, auth.id, payload.choiceIndex);
     } catch (err) {
-      socket.emit("error", { message: (err as Error).message });
+      const errMsg: ErrorPayload = { message: (err as Error).message };
+      socket.emit("error", errMsg);
     }
   });
 
   socket.on("disconnect", () => {
     lobbyManager.removeViewerEverywhere(auth.id);
   });
+}
+
+function broadcastQuestionResults(
+  io: SocketIOServer,
+  lobby: LobbyState,
+  result: { correct: number; stats: Map<number, number>; scoreboard: ScoreEntry[] }
+) {
+  const revealMsg: AnswerRevealPayload = {
+    correct: result.correct,
+    stats: Array.from(result.stats.entries()),
+  };
+  io.to(lobby.id).emit("answer_reveal", revealMsg);
+
+  // send recap to streamer
+  const recapMsg: QuestionRecapPayload = {
+    questionId: lobby.quiz.questions[lobby.currentQuestion].id,
+    correct: result.correct,
+    stats: Array.from(result.stats.entries()),
+    scoreboard: result.scoreboard,
+  };
+  io.to(lobby.hostSocketId).emit("question_recap", recapMsg);
+
+  for (const viewer of lobby.viewers.values()) {
+    const rank =
+      result.scoreboard.findIndex((s) => s.viewerId === viewer.id) + 1;
+    const score = lobby.scores.get(viewer.id) || 0;
+    let top: ScoreEntry[] = [];
+    if (rank <= 3) {
+      top = result.scoreboard.slice(0, 3);
+    } else {
+      top = [result.scoreboard[0], result.scoreboard[1], { viewerId: viewer.id, score }];
+    }
+    const payload: ScoreUpdatePayload = { score, rank, top };
+    io.to(viewer.socketId).emit("score_update", payload);
+  }
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -17,16 +17,20 @@ export interface ViewerInLobby {
 
 export interface LobbyConfig {
   maxPlayers: number;
+  questionDuration: number;
 }
 
 export interface LobbyState {
   id: string;
   hostId: string;
+  hostSocketId: string;
   quiz: QuizWithQuestions;
   config: LobbyConfig;
   viewers: Map<string, ViewerInLobby>;
+  scores: Map<string, number>;
   currentQuestion: number;
   answers: Map<string, Map<string, number>>;
+  questionTimer?: NodeJS.Timeout;
 }
 
 export interface QuizEndResult {

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -49,3 +49,69 @@ export type SocketEvent = {
     payload: SocketEventDefinition[K]["payload"];
   };
 }[keyof SocketEventDefinition];
+
+// Generic scoreboard entry
+export interface ScoreEntry {
+  viewerId: string;
+  score: number;
+}
+
+// Payload types for socket events
+export interface CreateLobbyPayload {
+  quizId: string;
+  config?: { maxPlayers?: number; questionDuration?: number };
+}
+export interface LobbyCreatedPayload {
+  lobbyId: string;
+}
+
+export interface JoinLobbyPayload {
+  lobbyId: string;
+}
+export interface LobbyJoinedPayload {
+  lobbyId: string;
+}
+
+export interface StartQuestionPayload {
+  lobbyId: string;
+}
+export interface QuestionStartedPayload {
+  id: string;
+  text: string;
+  choices: { index: number; text: string }[];
+  audioPromptKey?: string | null;
+}
+
+export interface SubmitAnswerPayload {
+  lobbyId: string;
+  choiceIndex: number;
+}
+
+export interface AnswerRevealPayload {
+  correct: number;
+  stats: [number, number][];
+}
+
+export interface QuestionRecapPayload {
+  questionId: string;
+  correct: number;
+  stats: [number, number][];
+  scoreboard: ScoreEntry[];
+}
+
+export interface ScoreUpdatePayload {
+  score: number;
+  rank: number;
+  top: ScoreEntry[];
+}
+
+export interface EndQuizPayload {
+  lobbyId: string;
+}
+export interface QuizEndedPayload {
+  results: ScoreEntry[];
+}
+
+export interface ErrorPayload {
+  message: string;
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -10,7 +10,8 @@ export type SocketDirection =
   | "server->web";
 
 // Mapping de chaque type d'événement à son payload et sa direction
-type SocketEventDefinition = {
+export type SocketEventDefinition = {
+  // --- Flux génériques existants ---
   join: {
     direction: "server->web";
     payload: { player: Viewer };
@@ -38,6 +39,64 @@ type SocketEventDefinition = {
   end: {
     direction: "server->viewer";
     payload: undefined;
+  };
+
+  // --- Gestion d'un quiz ---
+  create_lobby: {
+    direction: "web->server";
+    payload: CreateLobbyPayload;
+  };
+  lobby_created: {
+    direction: "server->web";
+    payload: LobbyCreatedPayload;
+  };
+  join_lobby: {
+    direction: "viewer->server";
+    payload: JoinLobbyPayload;
+  };
+  lobby_joined: {
+    direction: "server->viewer";
+    payload: LobbyJoinedPayload;
+  };
+  start_question: {
+    direction: "web->server";
+    payload: StartQuestionPayload;
+  };
+  question_started: {
+    direction: "server->viewer";
+    payload: QuestionStartedPayload;
+  };
+  submit_answer: {
+    direction: "viewer->server";
+    payload: SubmitAnswerPayload;
+  };
+  reveal_answer: {
+    direction: "web->server";
+    payload: StartQuestionPayload;
+  };
+  answer_reveal: {
+    direction: "server->viewer";
+    payload: AnswerRevealPayload;
+  };
+  question_recap: {
+    direction: "server->web";
+    payload: QuestionRecapPayload;
+  };
+  score_update: {
+    direction: "server->viewer";
+    payload: ScoreUpdatePayload;
+  };
+  end_quiz: {
+    direction: "web->server";
+    payload: EndQuizPayload;
+  };
+  quiz_ended: {
+    direction: "server->viewer";
+    payload: QuizEndedPayload;
+  };
+  error: {
+    direction: "server->viewer" | "server->web";
+    payload: ErrorPayload;
   };
 };
 


### PR DESCRIPTION
## Summary
- add structured socket payload types in shared package
- use shared payload types in the server socket handlers

## Testing
- `pnpm --filter server test`


------
https://chatgpt.com/codex/tasks/task_e_685ca149c69c83239b0216be4f0fa9ed