### PR TITLE
Preserve quiz participants

### DIFF
--- a/server/src/lobbyManager.ts
+++ b/server/src/lobbyManager.ts
@@ -42,6 +42,7 @@ class LobbyManager {
         questionDuration: config?.questionDuration ?? DEFAULT_QUESTION_DURATION,
       },
       viewers: new Map(),
+      participants: new Map(),
       scores: new Map(),
       currentQuestion: -1,
       answers: new Map(),
@@ -66,6 +67,7 @@ class LobbyManager {
     const lobby = this.lobbies.get(lobbyId);
     if (!lobby) throw new Error("Lobby not found");
     lobby.viewers.set(viewer.id, viewer);
+    lobby.participants.set(viewer.id, viewer);
     if (!lobby.scores.has(viewer.id)) {
       lobby.scores.set(viewer.id, 0);
     }
@@ -148,7 +150,7 @@ class LobbyManager {
 
     const results: QuizEndResult[] = [];
 
-    for (const viewer of lobby.viewers.values()) {
+    for (const viewer of lobby.participants.values()) {
       const viewerRecord = await prisma.viewer.upsert({
         where: { twitchUserId: viewer.id },
         update: { displayName: viewer.displayName },

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -27,6 +27,12 @@ export interface LobbyState {
   quiz: QuizWithQuestions;
   config: LobbyConfig;
   viewers: Map<string, ViewerInLobby>;
+  /**
+   * Tracks every viewer that has ever joined the lobby, even if they
+   * disconnect before the quiz ends. This allows us to persist results
+   * for players that left early.
+   */
+  participants: Map<string, ViewerInLobby>;
   scores: Map<string, number>;
   currentQuestion: number;
   answers: Map<string, Map<string, number>>;


### PR DESCRIPTION
## Summary
- keep a `participants` map in each lobby to store everyone that ever joined
- keep participants when users disconnect
- use participants when saving quiz results
- update tests to confirm disconnected players still appear in results
- add test to ensure reconnection works

## Testing
- `pnpm --filter server test`

------
https://chatgpt.com/codex/tasks/task_e_685ca9fdd9b88323a2eb52358f5d5781