### PR TITLE
Handle host disconnects gracefully

### DIFF
--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -72,6 +72,8 @@ function handleStreamer(
 ) {
   const userId = socket.data.userId as string;
 
+  lobbyManager.handleHostReconnect(userId, socket.id);
+
   socket.on(
     "create_lobby",
     async (payload: CreateLobbyPayload) => {
@@ -137,7 +139,7 @@ function handleStreamer(
   });
 
   socket.on("disconnect", () => {
-    lobbyManager.removeLobbiesByHost(userId);
+    lobbyManager.handleHostDisconnect(io, userId);
   });
 }
 
@@ -191,7 +193,9 @@ function broadcastQuestionResults(
     stats: Array.from(result.stats.entries()),
     scoreboard: result.scoreboard,
   };
-  io.to(lobby.hostSocketId).emit("question_recap", recapMsg);
+  if (lobby.hostSocketId) {
+    io.to(lobby.hostSocketId).emit("question_recap", recapMsg);
+  }
 
   for (const viewer of lobby.viewers.values()) {
     const rank =

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -23,7 +23,7 @@ export interface LobbyConfig {
 export interface LobbyState {
   id: string;
   hostId: string;
-  hostSocketId: string;
+  hostSocketId?: string;
   quiz: QuizWithQuestions;
   config: LobbyConfig;
   viewers: Map<string, ViewerInLobby>;
@@ -31,6 +31,7 @@ export interface LobbyState {
   currentQuestion: number;
   answers: Map<string, Map<string, number>>;
   questionTimer?: NodeJS.Timeout;
+  reconnectTimer?: NodeJS.Timeout;
 }
 
 export interface QuizEndResult {


### PR DESCRIPTION
## Summary
- keep quiz lobby around if streamer disconnects
- auto-end quiz after 1h without host reconnect
- don't wipe viewer scores before saving end results

## Testing
- `npx tsc -p server/tsconfig.json`
- `pnpm test` *(fails: ERR_PNPM_NO_SCRIPT Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_685ca9c73b288323969f793d0fe554fb