### PR TITLE
Repository cleanup

### DIFF
--- a/server/src/lobbyManager.ts
+++ b/server/src/lobbyManager.ts
@@ -15,6 +15,7 @@ import {
   QuizWithQuestions,
   QuizEndResult,
 } from "./types";
+import { QuizEndedPayload } from "@wizzy/shared";
 import { randomUUID } from "crypto";
 
 class LobbyManager {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -32,6 +32,7 @@ export interface LobbyState {
   currentQuestion: number;
   answers: Map<string, Map<string, number>>;
   questionStartedAt?: number;
+  questionTimer?: NodeJS.Timeout;
   reconnectTimer?: NodeJS.Timeout;
 }
 


### PR DESCRIPTION
## Summary
- restore `client` workspace reference in docs and config
- import shared QuizEndedPayload in lobby manager
- add missing `questionTimer` property to LobbyState interface

## Testing
- `pnpm --filter server build`
- `pnpm --filter server test`


------
https://chatgpt.com/codex/tasks/task_e_685cb03d0dd08323a75193d6749a5363