### PR TITLE
Handle lobby full via event

### DIFF
--- a/server/src/lobbyManager.ts
+++ b/server/src/lobbyManager.ts
@@ -95,14 +95,18 @@ class LobbyManager {
     this.lobbies.delete(id);
   }
 
-  joinLobby(lobbyId: string, viewer: ViewerInLobby) {
+  joinLobby(lobbyId: string, viewer: ViewerInLobby): boolean {
     const lobby = this.lobbies.get(lobbyId);
     if (!lobby) throw new Error("Lobby not found");
+    if (lobby.viewers.size >= lobby.config.maxPlayers) {
+      return false;
+    }
     lobby.viewers.set(viewer.id, viewer);
     lobby.participants.set(viewer.id, viewer);
     if (!lobby.scores.has(viewer.id)) {
       lobby.scores.set(viewer.id, 0);
     }
+    return true;
   }
 
   removeViewer(lobbyId: string, viewerId: string) {

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -58,6 +58,10 @@ export type SocketEventDefinition = {
     direction: "server->viewer";
     payload: LobbyJoinedPayload;
   };
+  lobby_full: {
+    direction: "server->viewer";
+    payload: LobbyFullPayload;
+  };
   start_question: {
     direction: "web->server";
     payload: StartQuestionPayload;
@@ -128,6 +132,9 @@ export interface JoinLobbyPayload {
   lobbyId: string;
 }
 export interface LobbyJoinedPayload {
+  lobbyId: string;
+}
+export interface LobbyFullPayload {
   lobbyId: string;
 }
 


### PR DESCRIPTION
## Summary
- add LobbyFullPayload and lobby_full event type
- joinLobby returns false when lobby is at capacity
- notify viewers with `lobby_full` socket event instead of throwing
- test lobby join denial when full

## Testing
- `npx --yes pnpm --filter server test`


------
https://chatgpt.com/codex/tasks/task_e_685cb5b53fdc832397024765d0a30199