### PR TITLE
Add new quiz page and update landing

### DIFF
--- a/web/app/dashboard/quiz/new/page.tsx
+++ b/web/app/dashboard/quiz/new/page.tsx
@@ -1,0 +1,11 @@
+import { getCurrentUser } from '@/lib/auth';
+import QuizForm from '@/components/quiz-form';
+
+export default async function NewQuizPage() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const quiz = { id: '', name: '', description: '', questions: [] };
+
+  return <QuizForm quiz={quiz} />;
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,11 +1,21 @@
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
 export default function Home() {
   return (
-    <main className="p-8 flex flex-col items-center gap-4">
-      <h1 className="text-3xl font-bold">Wizzy Dashboard</h1>
-      <a
-        className="underline text-purple-600"
-        href="/login"
-      >Login with Twitch</a>
+    <main className="p-8 flex justify-center">
+      <Card className="max-w-md text-center">
+        <CardHeader>
+          <CardTitle>Wizzy Dashboard</CardTitle>
+          <CardDescription>Host interactive quizzes directly on Twitch.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link href="/login">Login with Twitch</Link>
+          </Button>
+        </CardContent>
+      </Card>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- create dedicated `/dashboard/quiz/new` route
- enhance landing page with shadcn-ui `Card` and `Button`

## Testing
- `pnpm --filter server test`

------
https://chatgpt.com/codex/tasks/task_e_685ce29355108323b1af3aa0261a9890