### PR TITLE
Add new quiz page and update landing

### DIFF
--- a/web/app/dashboard/quiz/new/page.tsx
+++ b/web/app/dashboard/quiz/new/page.tsx
@@ -1,0 +1,11 @@
+import { getCurrentUser } from '@/lib/auth';
+import QuizForm from '@/components/quiz-form';
+
+export default async function NewQuizPage() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const quiz = { id: '', name: '', description: '', questions: [] };
+
+  return <QuizForm quiz={quiz} />;
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,11 +1,21 @@
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
 export default function Home() {
   return (
-    <main className="p-8 flex flex-col items-center gap-4">
-      <h1 className="text-3xl font-bold">Wizzy Dashboard</h1>
-      <a
-        className="underline text-purple-600"
-        href="/login"
-      >Login with Twitch</a>
+    <main className="p-8 flex justify-center">
+      <Card className="max-w-md text-center">
+        <CardHeader>
+          <CardTitle>Wizzy Dashboard</CardTitle>
+          <CardDescription>Host interactive quizzes directly on Twitch.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link href="/login">Login with Twitch</Link>
+          </Button>
+        </CardContent>
+      </Card>
     </main>
   );
 }

--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -1,80 +1,254 @@
-'use client';
-import { useState } from 'react';
-import { storeAudioBlob } from '@/lib/audio';
-import { Button } from '@/components/ui/button';
+'use client'
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Switch } from '@/components/ui/switch'
+import { FileDrop } from '@/components/ui/file-drop'
+import { exportQuiz, importQuiz } from '@/lib/quizIO'
+import { storeAudioBlob } from '@/lib/audio'
 
-interface Choice { id: string; text: string; index: number; }
-interface Question { id: string; text: string; choices: Choice[]; correctChoice: number; audioPromptKey?: string | null; audioRevealKey?: string | null; order: number; }
+interface Choice {
+  id: string
+  text: string
+  index: number
+}
+interface Question {
+  id: string
+  text: string
+  choices: Choice[]
+  correctChoice: number
+  audioPromptKey?: string | null
+  audioRevealKey?: string | null
+  order: number
+}
 
 export default function QuizForm({ quiz }: { quiz: any }) {
-  const [name, setName] = useState(quiz.name || '');
-  const [description, setDescription] = useState(quiz.description || '');
-  const [questions, setQuestions] = useState<Question[]>(quiz.questions || []);
+  const [name, setName] = useState(quiz.name || '')
+  const [description, setDescription] = useState(quiz.description || '')
+  const [questions, setQuestions] = useState<Question[]>(quiz.questions || [])
+  const [errors, setErrors] = useState<string[]>([])
+  const [tab, setTab] = useState<string>(quiz.questions?.[0]?.id || 'add')
 
-  const addQuestion = () => {
+  const handleAddQuestion = () => {
+    const id = crypto.randomUUID()
     setQuestions([
       ...questions,
-      { id: crypto.randomUUID(), text: '', choices: [], correctChoice: 0, order: questions.length },
-    ]);
-  };
+      {
+        id,
+        text: '',
+        choices: [],
+        correctChoice: 0,
+        order: questions.length,
+      },
+    ])
+    setTab(id)
+  }
+
+  const addChoice = (qIdx: number) => {
+    const copy = [...questions]
+    if (copy[qIdx].choices.length >= 4) return
+    copy[qIdx].choices.push({
+      id: crypto.randomUUID(),
+      text: '',
+      index: copy[qIdx].choices.length,
+    })
+    setQuestions(copy)
+  }
+
+  const updateChoice = (qIdx: number, cIdx: number, text: string) => {
+    const copy = [...questions]
+    copy[qIdx].choices[cIdx].text = text
+    setQuestions(copy)
+  }
+
+  const removeChoice = (qIdx: number, cIdx: number) => {
+    const copy = [...questions]
+    copy[qIdx].choices.splice(cIdx, 1)
+    setQuestions(copy)
+  }
+
+  const updateQuestionText = (idx: number, text: string) => {
+    const copy = [...questions]
+    copy[idx].text = text
+    setQuestions(copy)
+  }
+
+  const handleAudio = async (
+    idx: number,
+    type: 'prompt' | 'reveal',
+    file: File | null,
+  ) => {
+    if (!file) return
+    const key = await storeAudioBlob(file)
+    const copy = [...questions]
+    if (type === 'prompt') copy[idx].audioPromptKey = key
+    else copy[idx].audioRevealKey = key
+    setQuestions(copy)
+  }
+
+  const toggleAudio = (idx: number, enabled: boolean) => {
+    const copy = [...questions]
+    if (!enabled) {
+      copy[idx].audioPromptKey = null
+      copy[idx].audioRevealKey = null
+    }
+    setQuestions(copy)
+  }
+
+  const validate = () => {
+    const errs: string[] = []
+    if (!name.trim()) errs.push('Quiz name required')
+    if (questions.length === 0) errs.push('At least one question')
+    questions.forEach((q, i) => {
+      if (q.choices.length < 2 || q.choices.length > 4) {
+        errs.push(`Question ${i + 1} must have 2-4 choices`)
+      }
+    })
+    setErrors(errs)
+    return errs.length === 0
+  }
+
+  const handleExport = async () => {
+    const json = await exportQuiz({ id: quiz.id, name, description, questions })
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'quiz.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const handleImport = async (file: File | null) => {
+    if (!file) return
+    const text = await file.text()
+    const data = await importQuiz(text)
+    setName(data.name)
+    setDescription(data.description || '')
+    setQuestions(data.questions)
+  }
+
+  const onSubmit = () => {
+    if (!validate()) return
+    // TODO: submit to backend
+    console.log('submit', { name, description, questions })
+  }
 
   return (
-    <div className="p-4 space-y-4">
-      <div>
-        <input
-          className="border p-2 w-full"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Quiz name"
-        />
-      </div>
-      <div>
-        <textarea
-          className="border p-2 w-full"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="Description"
-        />
-      </div>
-      {questions.map((q, idx) => (
-        <div key={q.id} className="border p-2 space-y-2">
-          <input
-            className="border p-1 w-full"
-            value={q.text}
-            onChange={(e) => {
-              const copy = [...questions];
-              copy[idx].text = e.target.value;
-              setQuestions(copy);
-            }}
-            placeholder={`Question ${idx + 1}`}
-          />
-          {q.choices.map((c, cIdx) => (
-            <div key={c.id} className="flex gap-2 items-center">
-              <input
-                className="border p-1 flex-grow"
-                value={c.text}
-                onChange={(e) => {
-                  const copy = [...questions];
-                  copy[idx].choices[cIdx].text = e.target.value;
-                  setQuestions(copy);
-                }}
-                placeholder={`Choice ${cIdx + 1}`}
-              />
-              <Button type="button" onClick={() => {
-                const copy = [...questions];
-                copy[idx].choices.splice(cIdx,1);
-                setQuestions(copy);
-              }}>Remove</Button>
-            </div>
-          ))}
-          <Button type="button" onClick={() => {
-            const copy = [...questions];
-            copy[idx].choices.push({ id: crypto.randomUUID(), text: '', index: copy[idx].choices.length });
-            setQuestions(copy);
-          }}>Add Choice</Button>
+    <div className="space-y-4">
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1">
+          <Tabs value={tab} onValueChange={setTab} className="space-y-4">
+            <TabsList className="mb-4">
+              {questions.map((q, idx) => (
+                <TabsTrigger key={q.id} value={q.id}>
+                  {idx + 1}
+                </TabsTrigger>
+              ))}
+              <TabsTrigger value="add">Add question</TabsTrigger>
+            </TabsList>
+            {questions.map((q, idx) => {
+              const audioEnabled = Boolean(q.audioPromptKey || q.audioRevealKey)
+              return (
+                <TabsContent key={q.id} value={q.id} className="space-y-4">
+                  <Input
+                    value={q.text}
+                    onChange={(e) => updateQuestionText(idx, e.target.value)}
+                    placeholder="Question text"
+                  />
+                  {q.choices.map((c, cIdx) => (
+                    <div key={c.id} className="flex items-center gap-2">
+                      <Input
+                        value={c.text}
+                        onChange={(e) => updateChoice(idx, cIdx, e.target.value)}
+                        placeholder={`Choice ${cIdx + 1}`}
+                      />
+                      <Button type="button" variant="outline" onClick={() => removeChoice(idx, cIdx)}>
+                        Remove
+                      </Button>
+                    </div>
+                  ))}
+                  <Button type="button" onClick={() => addChoice(idx)} disabled={q.choices.length >= 4}>
+                    Add Choice
+                  </Button>
+                  <div className="flex items-center gap-2">
+                    <Switch checked={audioEnabled} onCheckedChange={(v) => toggleAudio(idx, v)} />
+                    <span className="text-sm">Add sound</span>
+                  </div>
+                  {audioEnabled && (
+                    <div className="flex flex-col gap-2">
+                      <FileDrop
+                        accept="audio/*"
+                        label="Question song"
+                        onFile={(f) => handleAudio(idx, 'prompt', f)}
+                      />
+                      <FileDrop
+                        accept="audio/*"
+                        label="Reveal song"
+                        onFile={(f) => handleAudio(idx, 'reveal', f)}
+                      />
+                    </div>
+                  )}
+                </TabsContent>
+              )
+            })}
+            <TabsContent value="add">
+              <Button type="button" onClick={handleAddQuestion}>
+                Add Question
+              </Button>
+            </TabsContent>
+          </Tabs>
         </div>
-      ))}
-      <Button type="button" onClick={addQuestion}>Add Question</Button>
+        <div className="flex flex-col gap-4 lg:w-1/3">
+          <Card>
+            <CardHeader>
+              <CardTitle>Quiz Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Quiz name" />
+              <textarea
+                className="w-full rounded-md border p-2"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Description"
+              />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Import / Export</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <input
+                type="file"
+                accept="application/json"
+                onChange={(e) => handleImport(e.target.files?.[0] || null)}
+              />
+              <Button type="button" onClick={handleExport}>
+                Export
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      {errors.length > 0 && (
+        <Card className="border-destructive">
+          <CardContent className="space-y-1 text-destructive">
+            {errors.map((e) => (
+              <div key={e}>{e}</div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+      <Button onClick={onSubmit}>Save Quiz</Button>
     </div>
-  );
+  )
 }

--- a/web/components/ui/file-drop.tsx
+++ b/web/components/ui/file-drop.tsx
@@ -1,0 +1,42 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface FileDropProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "type"> {
+  onFile: (file: File | null) => void
+  label?: React.ReactNode
+}
+
+export function FileDrop({ onFile, label = "Drop or click", className, accept, ...props }: FileDropProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onFile(e.target.files?.[0] || null)
+  }
+  const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault()
+    onFile(e.dataTransfer.files?.[0] || null)
+  }
+  const handleClick = () => inputRef.current?.click()
+
+  return (
+    <label
+      onClick={handleClick}
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      className={cn(
+        "flex h-24 cursor-pointer items-center justify-center rounded-md border border-dashed p-2 text-sm",
+        className,
+      )}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        onChange={handleChange}
+        className="hidden"
+        {...props}
+      />
+      {label}
+    </label>
+  )
+}

--- a/web/lib/quizIO.ts
+++ b/web/lib/quizIO.ts
@@ -1,4 +1,4 @@
-import { hasAudio, getAudioBlob } from './audio';
+import { getAudioBlob, storeAudioBlob } from './audio';
 
 export async function exportQuiz(quiz: any) {
   const questions = await Promise.all(
@@ -13,6 +13,44 @@ export async function exportQuiz(quiz: any) {
     })
   );
   return JSON.stringify({ ...quiz, questions }, null, 2);
+}
+
+export async function importQuiz(json: string) {
+  const data = JSON.parse(json);
+  const questions = await Promise.all(
+    data.questions.map(async (q: any) => {
+      const {
+        audioPrompt,
+        audioReveal,
+        audioPromptKey,
+        audioRevealKey,
+        ...rest
+      } = q;
+      let promptKey = audioPromptKey ?? null;
+      if (audioPrompt && !promptKey) {
+        const blob = dataUrlToBlob(audioPrompt);
+        promptKey = await storeAudioBlob(blob);
+      }
+      let revealKey = audioRevealKey ?? null;
+      if (audioReveal && !revealKey) {
+        const blob = dataUrlToBlob(audioReveal);
+        revealKey = await storeAudioBlob(blob);
+      }
+      return { ...rest, audioPromptKey: promptKey, audioRevealKey: revealKey };
+    }),
+  );
+  return { ...data, questions };
+}
+
+function dataUrlToBlob(dataUrl: string) {
+  const [header, base64] = dataUrl.split(',');
+  const mime = header.match(/:(.*);/)?.[1] || 'application/octet-stream';
+  const binary = atob(base64);
+  const array = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    array[i] = binary.charCodeAt(i);
+  }
+  return new Blob([array], { type: mime });
 }
 
 function blobToBase64(blob: Blob) {


### PR DESCRIPTION
## Summary
- create dedicated `/dashboard/quiz/new` route
- enhance landing page with shadcn-ui `Card` and `Button`
- refactor quiz form with shadcn components, audio upload, validation and JSON import/export
- add tabbed question editor with audio toggle and drag-drop input

## Testing
- `pnpm --filter server test`


------
https://chatgpt.com/codex/tasks/task_e_685ce29355108323b1af3aa0261a9890