### PR TITLE
Fix quiz update route and async params

### DIFF
--- a/web/app/dashboard/live/[lobbyId]/page.tsx
+++ b/web/app/dashboard/live/[lobbyId]/page.tsx
@@ -4,7 +4,8 @@ import LiveClient from './LiveClient';
 interface Props { params: { lobbyId: string } }
 
 export default async function LivePage({ params }: Props) {
+  const { lobbyId } = await params;
   const user = await getCurrentUser();
   if (!user) return null;
-  return <LiveClient lobbyId={params.lobbyId} accessToken={user.accessToken || ''} />;
+  return <LiveClient lobbyId={lobbyId} accessToken={user.accessToken || ''} />;
 }

--- a/web/app/dashboard/quiz/[id]/page.tsx
+++ b/web/app/dashboard/quiz/[id]/page.tsx
@@ -6,7 +6,7 @@ import QuizForm from '@/components/quiz-form';
 interface Props { params: { id: string } }
 
 export default async function QuizPage({ params }: Props) {
-  const { id } = params;
+  const { id } = await params;
   const user = await getCurrentUser();
   if (!user) return null;
 

--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -237,12 +237,20 @@ export default function QuizForm({ quiz }: { quiz: any }) {
                         <div className="flex flex-col gap-2">
                           <FileDrop
                             accept="audio/*"
-                            label="Question song"
+                            label={
+                              q.audioPromptKey
+                                ? `Question song: ${q.audioPromptKey}`
+                                : 'Question song'
+                            }
                             onFile={(f) => handleAudio(idx, 'prompt', f)}
                           />
                           <FileDrop
                             accept="audio/*"
-                            label="Reveal song"
+                            label={
+                              q.audioRevealKey
+                                ? `Reveal song: ${q.audioRevealKey}`
+                                : 'Reveal song'
+                            }
                             onFile={(f) => handleAudio(idx, 'reveal', f)}
                           />
                         </div>


### PR DESCRIPTION
## Summary
- handle async params for dynamic pages
- clean up API route for updating quizzes
- delete quiz choices before questions
- show uploaded audio IDs

## Testing
- `pnpm --filter web lint` *(fails: Unexpected any & Next.js lint rules)*
- `pnpm --filter web build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685e21c824288323ae220f54e6cd9f90