### PR TITLE
Add playback to audio drag-n-drop

### DIFF
--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -242,6 +242,7 @@ export default function QuizForm({ quiz }: { quiz: any }) {
                                 ? `Question song: ${q.audioPromptKey}`
                                 : 'Question song'
                             }
+                            playKey={q.audioPromptKey ?? undefined}
                             onFile={(f) => handleAudio(idx, 'prompt', f)}
                           />
                           <FileDrop
@@ -251,6 +252,7 @@ export default function QuizForm({ quiz }: { quiz: any }) {
                                 ? `Reveal song: ${q.audioRevealKey}`
                                 : 'Reveal song'
                             }
+                            playKey={q.audioRevealKey ?? undefined}
                             onFile={(f) => handleAudio(idx, 'reveal', f)}
                           />
                         </div>

--- a/web/components/ui/file-drop.tsx
+++ b/web/components/ui/file-drop.tsx
@@ -1,13 +1,15 @@
 "use client"
 import * as React from "react"
+import { PlayIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 interface FileDropProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "type"> {
   onFile: (file: File | null) => void
   label?: React.ReactNode
+  playKey?: string | null
 }
 
-export function FileDrop({ onFile, label = "Drop or click", className, accept, ...props }: FileDropProps) {
+export function FileDrop({ onFile, label = "Drop or click", playKey, className, accept, ...props }: FileDropProps) {
   const inputRef = React.useRef<HTMLInputElement>(null)
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onFile(e.target.files?.[0] || null)
@@ -17,6 +19,17 @@ export function FileDrop({ onFile, label = "Drop or click", className, accept, .
     onFile(e.dataTransfer.files?.[0] || null)
   }
   const handleClick = () => inputRef.current?.click()
+  const play = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    if (!playKey) return
+    const { getAudioBlob } = await import("@/lib/audio")
+    const blob = await getAudioBlob(playKey)
+    if (!blob) return
+    const url = URL.createObjectURL(blob)
+    const audio = new Audio(url)
+    audio.play()
+    audio.addEventListener("ended", () => URL.revokeObjectURL(url))
+  }
 
   return (
     <label
@@ -24,7 +37,7 @@ export function FileDrop({ onFile, label = "Drop or click", className, accept, .
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
       className={cn(
-        "flex h-24 cursor-pointer items-center justify-center rounded-md border border-dashed p-2 text-sm",
+        "relative flex h-24 cursor-pointer items-center justify-center rounded-md border border-dashed p-2 text-sm",
         className,
       )}
     >
@@ -36,6 +49,15 @@ export function FileDrop({ onFile, label = "Drop or click", className, accept, .
         className="hidden"
         {...props}
       />
+      {playKey && (
+        <button
+          type="button"
+          onClick={play}
+          className="absolute right-1 top-1 rounded-sm bg-background/70 p-1 hover:bg-background"
+        >
+          <PlayIcon className="size-4" />
+        </button>
+      )}
       {label}
     </label>
   )


### PR DESCRIPTION
## Summary
- add Play icon button in FileDrop so songs can be previewed
- expose `playKey` prop in FileDrop
- let quiz form pass the audio key to FileDrop

## Testing
- `pnpm --filter web lint` *(fails: Unexpected any and other lint errors)*
- `pnpm --filter web build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685f144b36f48323a11ab6f32aa125e1