### PR TITLE
Add toast error handling

### DIFF
--- a/web/app/dashboard/live/[lobbyId]/LiveClient.tsx
+++ b/web/app/dashboard/live/[lobbyId]/LiveClient.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@wizzy/shared";
 import { DEFAULT_QUESTION_DURATION } from "@wizzy/shared";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 
 type EventsByDirection<D extends SocketDirection> = {
   [K in keyof SocketEventDefinition as D extends SocketEventDefinition[K]["direction"]
@@ -56,6 +57,13 @@ export default function LiveClient({ lobbyId, accessToken }: Props) {
     );
     socketRef.current = socket;
     socket.connect();
+
+    socket.on("connect_error", () => {
+      toast.error("Failed to connect to server");
+    });
+    socket.on("disconnect", (reason) => {
+      toast.error(`Disconnected: ${reason}`);
+    });
 
     socket.on("question_started", (q: QuestionStartedPayload) => {
       setQuestion(q);

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -32,6 +33,7 @@ export default function RootLayout({
           </form>
         </header>
         {children}
+        <Toaster richColors />
       </body>
     </html>
   );

--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -14,6 +14,7 @@ import { Switch } from '@/components/ui/switch'
 import { FileDrop } from '@/components/ui/file-drop'
 import { exportQuiz, importQuiz } from '@/lib/quizIO'
 import { storeAudioBlob } from '@/lib/audio'
+import { toast } from '@/components/ui/sonner'
 
 interface Choice {
   id: string
@@ -168,6 +169,7 @@ export default function QuizForm({ quiz }: { quiz: any }) {
     } else {
       const msg = await res.text()
       setErrors([msg || 'Failed to save'])
+      toast.error(msg || 'Failed to save')
     }
   }
 

--- a/web/components/ui/sonner.tsx
+++ b/web/components/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, ToasterProps, toast } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
@@ -22,4 +22,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+export { Toaster, toast }


### PR DESCRIPTION
## Summary
- expose `toast` helper for app components
- add toaster to global layout
- show toast on websocket errors
- toast quiz save failures

## Testing
- `pnpm --filter web lint` *(fails: `next lint` errors)*
- `pnpm --filter server test`

------
https://chatgpt.com/codex/tasks/task_e_685f33256fa88323b619849e0c424e44