### PR TITLE
Redesign landing page in dark mode

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import type { Metadata } from "next"
+import { Geist, Geist_Mono } from "next/font/google"
+import Link from "next/link"
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 
@@ -21,20 +22,30 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <header className="p-4 border-b">
-          <a href="/" className="font-bold">Wizzy</a>
-          <form className="float-right" action="/api/auth/logout" method="post">
-            <button type="submit" className="underline text-sm">Logout</button>
-          </form>
+        <header className="sticky top-0 z-50 w-full bg-gradient-to-b from-black/70 to-transparent">
+          <div className="max-w-screen-xl mx-auto flex items-center justify-between py-6 px-8">
+            <Link href="/" className="flex items-center gap-2 font-bold text-white">
+              <span role="img" aria-label="wizard">🧙‍♂️</span>
+              <span>Wizzy</span>
+            </Link>
+            <nav className="flex items-center gap-8">
+              <a href="#features" className="text-white hover:underline">Features</a>
+              <form action="/api/auth/logout" method="post">
+                <button type="submit" className="underline text-sm text-white">
+                  Logout
+                </button>
+              </form>
+            </nav>
+          </div>
         </header>
         {children}
         <Toaster richColors />
       </body>
     </html>
-  );
+  )
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,21 +1,41 @@
-import Link from 'next/link';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import Link from 'next/link'
+import { Plug, Palette, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+function Feature({ icon, title, description }: { icon: React.ReactNode; title: string; description: string }) {
+  return (
+    <div className="group text-center transition-transform hover:-translate-y-1">
+      <div className="flex justify-center mb-4 text-white">{icon}</div>
+      <h3 className="text-xl font-bold mb-2 text-white">{title}</h3>
+      <p className="text-[#C0C0C0]">{description}</p>
+    </div>
+  )
+}
 
 export default function Home() {
   return (
-    <main className="p-8 flex justify-center">
-      <Card className="max-w-md text-center">
-        <CardHeader>
-          <CardTitle>Wizzy Dashboard</CardTitle>
-          <CardDescription>Host interactive quizzes directly on Twitch.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Button asChild>
-            <Link href="/login">Login with Twitch</Link>
-          </Button>
-        </CardContent>
-      </Card>
+    <main className="bg-[#0E0E12] text-white">
+      <section className="min-h-screen flex items-center bg-gradient-to-br from-[#121218] to-[#0E0E12] px-8">
+        <div className="mx-auto w-full max-w-screen-xl grid md:grid-cols-2 gap-16 items-center">
+          <div className="space-y-6 md:pr-8">
+            <h1 className="text-4xl md:text-6xl font-extrabold">Interactive quizzes for your stream</h1>
+            <p className="text-[#C0C0C0] text-lg max-w-md">Wizzy lets you run live quizzes to boost viewer engagement. Free and easy to set up.</p>
+            <Button asChild size="lg" className="bg-[#9147FF] hover:bg-[#A974FF] transition-transform hover:scale-105 px-8 py-4 rounded-lg">
+              <Link href="/login">Get Started</Link>
+            </Button>
+          </div>
+          <div className="flex justify-center">
+            <div className="relative w-full max-w-md aspect-video rounded-xl border-2 border-purple-500/50 shadow-lg overflow-hidden hover:border-purple-400 transition" />
+          </div>
+        </div>
+      </section>
+      <section id="features" className="bg-[#15151A] py-20 px-8">
+        <div className="mx-auto max-w-screen-xl grid md:grid-cols-3 gap-16">
+          <Feature icon={<Plug className="size-8 text-[#9147FF]" />} title="Easy to set up" description="Get running in minutes with simple onboarding." />
+          <Feature icon={<Palette className="size-8 text-[#9147FF]" />} title="Fully customizable" description="Brand it your way with colors, layout, and more." />
+          <Feature icon={<Clock className="size-8 text-[#9147FF]" />} title="Real-time feedback" description="See results instantly to keep viewers engaged." />
+        </div>
+      </section>
     </main>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- turn on dark mode by default
- implement new sticky navigation
- create a dark hero section with features list

## Testing
- `pnpm -r run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685f72a01e588323b2d467200edad890