### PR TITLE
Add profile dropdown and dynamic hero link

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google"
 import Link from "next/link"
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
+import { getCurrentUser } from "@/lib/auth"
+import ProfileMenu from "@/components/profile-menu"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -19,11 +21,12 @@ export const metadata: Metadata = {
   description: "Quiz dashboard",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const user = await getCurrentUser()
   return (
     <html lang="en" className="dark">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
@@ -35,11 +38,13 @@ export default function RootLayout({
             </Link>
             <nav className="flex items-center gap-8">
               <a href="#features" className="text-white hover:underline">Features</a>
-              <form action="/api/auth/logout" method="post">
-                <button type="submit" className="underline text-sm text-white">
-                  Logout
-                </button>
-              </form>
+              {user ? (
+                <ProfileMenu user={user} />
+              ) : (
+                <Link href="/login" className="underline text-sm text-white">
+                  Login
+                </Link>
+              )}
             </nav>
           </div>
         </header>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { Plug, Palette, Clock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { getCurrentUser } from '@/lib/auth'
 
 function Feature({ icon, title, description }: { icon: React.ReactNode; title: string; description: string }) {
   return (
@@ -12,7 +13,8 @@ function Feature({ icon, title, description }: { icon: React.ReactNode; title: s
   )
 }
 
-export default function Home() {
+export default async function Home() {
+  const user = await getCurrentUser()
   return (
     <main className="bg-[#0E0E12] text-white">
       <section className="min-h-screen flex items-center bg-gradient-to-br from-[#121218] to-[#0E0E12] px-8">
@@ -21,7 +23,7 @@ export default function Home() {
             <h1 className="text-4xl md:text-6xl font-extrabold">Interactive quizzes for your stream</h1>
             <p className="text-[#C0C0C0] text-lg max-w-md">Wizzy lets you run live quizzes to boost viewer engagement. Free and easy to set up.</p>
             <Button asChild size="lg" className="bg-[#9147FF] hover:bg-[#A974FF] transition-transform hover:scale-105 px-8 py-4 rounded-lg">
-              <Link href="/login">Get Started</Link>
+              <Link href={user ? "/dashboard" : "/login"}>{user ? "Dashboard" : "Get Started"}</Link>
             </Button>
           </div>
           <div className="flex justify-center">

--- a/web/components/profile-menu.tsx
+++ b/web/components/profile-menu.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+
+interface Props {
+  user: { displayName: string; profileImageUrl: string }
+}
+
+export default function ProfileMenu({ user }: Props) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="rounded-full transition-transform hover:scale-110 focus:outline-none"
+      >
+        <Avatar className="size-8">
+          <AvatarImage src={user.profileImageUrl} alt={user.displayName} />
+          <AvatarFallback>{user.displayName.charAt(0)}</AvatarFallback>
+        </Avatar>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 rounded-md border bg-popover text-popover-foreground shadow-md">
+          <form action="/api/auth/logout" method="post">
+            <button
+              type="submit"
+              className="block w-full px-3 py-2 text-left text-sm hover:bg-accent"
+            >
+              Logout
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show dashboard link on homepage when logged in
- display a profile avatar with dropdown logout option

## Testing
- `pnpm --filter web lint` *(fails: Unexpected any etc.)*
- `pnpm --filter server test`

------
https://chatgpt.com/codex/tasks/task_e_685f76502a5483238a9023f39a884954