### PR TITLE
Add typed prisma payloads

### DIFF
--- a/web/app/api/quiz/[id]/route.ts
+++ b/web/app/api/quiz/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { getCurrentUser } from '@/lib/auth'
+import type { QuizPayload } from '@/lib/types'
 
 interface Props { params: { id: string } }
 
@@ -8,7 +9,7 @@ export async function PUT(req: Request, { params }: Props) {
   const { id } = await params
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const data = await req.json()
+  const data = (await req.json()) as QuizPayload
   const { name, description, questions } = data
 
   const existing = await prisma.quiz.findUnique({
@@ -30,14 +31,14 @@ export async function PUT(req: Request, { params }: Props) {
       name,
       description,
       questions: {
-        create: questions.map((q: any, idx: number) => ({
+        create: questions.map((q, idx) => ({
           text: q.text,
           audioPromptKey: q.audioPromptKey,
           audioRevealKey: q.audioRevealKey,
           correctChoice: q.correctChoice,
           order: idx,
           choices: {
-            create: q.choices.map((c: any) => ({ text: c.text, index: c.index })),
+            create: q.choices.map((c) => ({ text: c.text, index: c.index })),
           },
         })),
       },

--- a/web/app/api/quiz/route.ts
+++ b/web/app/api/quiz/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { getCurrentUser } from '@/lib/auth'
+import type { QuizPayload } from '@/lib/types'
 
 export async function POST(req: Request) {
   const user = await getCurrentUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const data = await req.json()
+  const data = (await req.json()) as QuizPayload
   const { name, description, questions } = data
   const quiz = await prisma.quiz.create({
     data: {
@@ -13,14 +14,14 @@ export async function POST(req: Request) {
       description,
       ownerId: user.id,
       questions: {
-        create: questions.map((q: any, idx: number) => ({
+        create: questions.map((q, idx) => ({
           text: q.text,
           audioPromptKey: q.audioPromptKey,
           audioRevealKey: q.audioRevealKey,
           correctChoice: q.correctChoice,
           order: idx,
           choices: {
-            create: q.choices.map((c: any) => ({ text: c.text, index: c.index })),
+            create: q.choices.map((c) => ({ text: c.text, index: c.index })),
           },
         })),
       },

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,10 @@ import { Geist, Geist_Mono } from "next/font/google"
 import Link from "next/link"
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
+import { getCurrentUser } from "@/lib/auth"
+import ProfileMenu from "@/components/profile-menu"
+import ErrorScreen from "@/components/error-screen"
+import { tryWithError } from "@/lib/try-with-error"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -19,11 +23,22 @@ export const metadata: Metadata = {
   description: "Quiz dashboard",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const [user, userError] = await tryWithError(() => getCurrentUser())
+  if (userError) {
+    return (
+      <html lang="en" className="dark">
+        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+          <ErrorScreen title="Database Unreachable" />
+          <Toaster richColors />
+        </body>
+      </html>
+    )
+  }
   return (
     <html lang="en" className="dark">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
@@ -35,11 +50,13 @@ export default function RootLayout({
             </Link>
             <nav className="flex items-center gap-8">
               <a href="#features" className="text-white hover:underline">Features</a>
-              <form action="/api/auth/logout" method="post">
-                <button type="submit" className="underline text-sm text-white">
-                  Logout
-                </button>
-              </form>
+              {user ? (
+                <ProfileMenu user={user} />
+              ) : (
+                <Link href="/login" className="underline text-sm text-white">
+                  Login
+                </Link>
+              )}
             </nav>
           </div>
         </header>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 import { Plug, Palette, Clock } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { getCurrentUser } from '@/lib/auth'
+import ErrorScreen from '@/components/error-screen'
+import { tryWithError } from '@/lib/try-with-error'
 
 function Feature({ icon, title, description }: { icon: React.ReactNode; title: string; description: string }) {
   return (
@@ -12,7 +15,9 @@ function Feature({ icon, title, description }: { icon: React.ReactNode; title: s
   )
 }
 
-export default function Home() {
+export default async function Home() {
+  const [user, userError] = await tryWithError(() => getCurrentUser())
+  if (userError) return <ErrorScreen title="Database Unreachable" />
   return (
     <main className="bg-[#0E0E12] text-white">
       <section className="min-h-screen flex items-center bg-gradient-to-br from-[#121218] to-[#0E0E12] px-8">
@@ -21,7 +26,7 @@ export default function Home() {
             <h1 className="text-4xl md:text-6xl font-extrabold">Interactive quizzes for your stream</h1>
             <p className="text-[#C0C0C0] text-lg max-w-md">Wizzy lets you run live quizzes to boost viewer engagement. Free and easy to set up.</p>
             <Button asChild size="lg" className="bg-[#9147FF] hover:bg-[#A974FF] transition-transform hover:scale-105 px-8 py-4 rounded-lg">
-              <Link href="/login">Get Started</Link>
+              <Link href={user ? "/dashboard" : "/login"}>{user ? "Dashboard" : "Get Started"}</Link>
             </Button>
           </div>
           <div className="flex justify-center">

--- a/web/components/profile-menu.tsx
+++ b/web/components/profile-menu.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
+
+interface Props {
+  user: { displayName: string; profileImageUrl: string }
+}
+
+export default function ProfileMenu({ user }: Props) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="rounded-full transition-transform hover:scale-110 focus:outline-none"
+      >
+        <Avatar className="size-8">
+          <AvatarImage src={user.profileImageUrl} alt={user.displayName} />
+          <AvatarFallback>{user.displayName.charAt(0)}</AvatarFallback>
+        </Avatar>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 rounded-md border bg-popover text-popover-foreground shadow-md">
+          <form action="/api/auth/logout" method="post">
+            <button
+              type="submit"
+              className="block w-full px-3 py-2 text-left text-sm hover:bg-accent"
+            >
+              Logout
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -15,28 +15,17 @@ import { FileDrop } from '@/components/ui/file-drop'
 import { exportQuiz, importQuiz } from '@/lib/quizIO'
 import { storeAudioBlob } from '@/lib/audio'
 import { toast } from '@/components/ui/sonner'
+import type { QuizPayload, QuestionPayload } from '@/lib/types'
 
-interface Choice {
-  id: string
-  text: string
-  index: number
-}
-interface Question {
-  id: string
-  text: string
-  choices: Choice[]
-  correctChoice: number
-  audioPromptKey?: string | null
-  audioRevealKey?: string | null
-  order: number
+interface QuestionForm extends QuestionPayload {
   audioEnabled?: boolean
 }
 
-export default function QuizForm({ quiz }: { quiz: any }) {
+export default function QuizForm({ quiz }: { quiz: QuizPayload & { id: string } }) {
   const [name, setName] = useState(quiz.name || '')
   const [description, setDescription] = useState(quiz.description || '')
-  const [questions, setQuestions] = useState<Question[]>(
-    (quiz.questions || []).map((q: any) => ({
+  const [questions, setQuestions] = useState<QuestionForm[]>(
+    (quiz.questions || []).map((q) => ({
       ...q,
       audioEnabled: Boolean(q.audioPromptKey || q.audioRevealKey),
     }))
@@ -144,7 +133,7 @@ export default function QuizForm({ quiz }: { quiz: any }) {
     setName(data.name)
     setDescription(data.description || '')
     setQuestions(
-      data.questions.map((q: any) => ({
+      data.questions.map((q) => ({
         ...q,
         audioEnabled: Boolean(q.audioPromptKey || q.audioRevealKey),
       }))
@@ -157,7 +146,10 @@ export default function QuizForm({ quiz }: { quiz: any }) {
     const payload = {
       name,
       description,
-      questions: questions.map(({ audioEnabled, ...q }) => q),
+      questions: questions.map((q) => {
+        const { audioEnabled: _, ...rest } = q // eslint-disable-line @typescript-eslint/no-unused-vars
+        return rest
+      }),
     }
     const res = await fetch(quiz.id ? `/api/quiz/${quiz.id}` : '/api/quiz', {
       method: quiz.id ? 'PUT' : 'POST',

--- a/web/lib/quizIO.ts
+++ b/web/lib/quizIO.ts
@@ -1,8 +1,9 @@
-import { getAudioBlob, storeAudioBlob } from './audio';
+import { getAudioBlob, storeAudioBlob } from './audio'
+import type { QuizPayload, QuestionPayload } from './types'
 
-export async function exportQuiz(quiz: any) {
+export async function exportQuiz(quiz: QuizPayload & { id: string }) {
   const questions = await Promise.all(
-    quiz.questions.map(async (q: any) => {
+    quiz.questions.map(async (q: QuestionPayload) => {
       const prompt = q.audioPromptKey && (await getAudioBlob(q.audioPromptKey));
       const reveal = q.audioRevealKey && (await getAudioBlob(q.audioRevealKey));
       return {
@@ -15,10 +16,10 @@ export async function exportQuiz(quiz: any) {
   return JSON.stringify({ ...quiz, questions }, null, 2);
 }
 
-export async function importQuiz(json: string) {
-  const data = JSON.parse(json);
+export async function importQuiz(json: string): Promise<QuizPayload & { id?: string }> {
+  const data = JSON.parse(json) as QuizPayload & { id?: string };
   const questions = await Promise.all(
-    data.questions.map(async (q: any) => {
+    data.questions.map(async (q) => {
       const {
         audioPrompt,
         audioReveal,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,0 +1,25 @@
+import type { Prisma } from '@wizzy/prisma'
+
+// Prisma models with related questions and choices
+export type QuizWithQuestions = Prisma.QuizGetPayload<{
+  include: { questions: { include: { choices: true } } }
+}>
+
+export type QuestionWithChoices = Prisma.QuestionGetPayload<{
+  include: { choices: true }
+}>
+
+// Payload shapes for API requests
+export type ChoicePayload = Omit<Prisma.Choice, 'id' | 'questionId'> & {
+  id?: string
+}
+export type QuestionPayload =
+  Omit<Prisma.Question, 'id' | 'quizId'> & {
+    id?: string
+    choices: ChoicePayload[]
+  }
+export type QuizPayload =
+  Omit<Prisma.Quiz, 'id' | 'ownerId' | 'createdAt'> & {
+    id?: string
+    questions: QuestionPayload[]
+  }


### PR DESCRIPTION
## Summary
- refactor web type helpers to use Prisma models
- update quiz form and utils to the new payload types

## Testing
- `pnpm --filter web lint`
- `pnpm --filter server test`


------
https://chatgpt.com/codex/tasks/task_e_685f76502a5483238a9023f39a884954