### PR TITLE
Add play/pause toggle for quiz audio

### DIFF
--- a/web/components/ui/file-drop.tsx
+++ b/web/components/ui/file-drop.tsx
@@ -1,7 +1,10 @@
 "use client"
 import * as React from "react"
-import { PlayIcon } from "lucide-react"
+import { PlayIcon, PauseIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
+
+let currentAudio: HTMLAudioElement | null = null
+let currentKey: string | null = null
 
 interface FileDropProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "type"> {
   onFile: (file: File | null) => void
@@ -11,6 +14,7 @@ interface FileDropProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>
 
 export function FileDrop({ onFile, label = "Drop or click", playKey, className, accept, ...props }: FileDropProps) {
   const inputRef = React.useRef<HTMLInputElement>(null)
+  const [playing, setPlaying] = React.useState(false)
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onFile(e.target.files?.[0] || null)
   }
@@ -22,13 +26,41 @@ export function FileDrop({ onFile, label = "Drop or click", playKey, className, 
   const play = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     if (!playKey) return
+
+    if (currentAudio && currentKey === playKey) {
+      if (!currentAudio.paused) {
+        currentAudio.pause()
+        setPlaying(false)
+        currentAudio = null
+        currentKey = null
+      } else {
+        currentAudio.play()
+        setPlaying(true)
+      }
+      return
+    }
+
+    if (currentAudio) {
+      currentAudio.pause()
+    }
+
     const { getAudioBlob } = await import("@/lib/audio")
     const blob = await getAudioBlob(playKey)
     if (!blob) return
     const url = URL.createObjectURL(blob)
     const audio = new Audio(url)
+    currentAudio = audio
+    currentKey = playKey
+    setPlaying(true)
     audio.play()
-    audio.addEventListener("ended", () => URL.revokeObjectURL(url))
+    audio.addEventListener("ended", () => {
+      URL.revokeObjectURL(url)
+      setPlaying(false)
+      if (currentAudio === audio) {
+        currentAudio = null
+        currentKey = null
+      }
+    })
   }
 
   return (
@@ -55,7 +87,12 @@ export function FileDrop({ onFile, label = "Drop or click", playKey, className, 
           onClick={play}
           className="absolute right-1 top-1 rounded-sm bg-background/70 p-1 hover:bg-background"
         >
-          <PlayIcon className="size-4" />
+          {playing ? (
+            <PauseIcon className="size-4" />
+          ) : (
+            <PlayIcon className="size-4" />
+          )}
+          <span className="sr-only">{playing ? "Pause" : "Play"}</span>
         </button>
       )}
       {label}


### PR DESCRIPTION
## Summary
- make only one audio play at a time for quiz uploads
- swap play/pause icon on audio buttons

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685f808775a88323ba65b473f9e533d7