### PR TITLE
Fix navbar to be permanently fixed

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -43,8 +43,8 @@ export default async function RootLayout({
 
   return (
     <html lang="en" className="dark">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <header className="sticky top-0 z-50 w-full bg-gradient-to-b from-black/70 to-transparent">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased pt-20`}>
+        <header className="fixed top-0 left-0 z-50 w-full bg-gradient-to-b from-black/70 to-transparent">
           <div className="max-w-screen-xl mx-auto flex items-center justify-between py-6 px-8">
             <Link href="/" className="flex items-center gap-2 font-bold text-white">
               <span role="img" aria-label="wizard">🧙‍♂️</span>


### PR DESCRIPTION
## Summary
- keep the navbar fixed to the top
- offset body content so the fixed header does not overlap

## Testing
- `pnpm --filter server test`

------
https://chatgpt.com/codex/tasks/task_e_68615df621f48323bece7eaf0e268d1c