### PR TITLE
Refactor quiz editor layout

### DIFF
--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -1,21 +1,26 @@
 'use client'
 
 import { useState } from 'react'
-import { Input } from '@/components/ui/input'
-import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-} from '@/components/ui/card'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Switch } from '@/components/ui/switch'
 import { FileDrop } from '@/components/ui/file-drop'
-import { exportQuiz, importQuiz } from '@/lib/quizIO'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { Trash2, Settings } from 'lucide-react'
+import { Inter } from 'next/font/google'
+import { cn } from '@/lib/utils'
 import { storeAudioBlob } from '@/lib/audio'
 import { toast } from '@/components/ui/sonner'
+import { exportQuiz, importQuiz } from '@/lib/quizIO'
 import type { QuizPayload, QuestionPayload } from '@/lib/types'
+
+const inter = Inter({ subsets: ['latin'] })
 
 interface QuestionForm extends QuestionPayload {
   audioEnabled?: boolean
@@ -166,156 +171,180 @@ export default function QuizForm({ quiz }: { quiz: QuizPayload & { id: string } 
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-6 lg:flex-row">
-        <div className="flex-1">
-          <Tabs value={tab} onValueChange={setTab} className="space-y-4">
-            <TabsList className="mb-4">
-              {questions.map((q, idx) => (
-                <TabsTrigger key={q.id} value={q.id}>
-                  {idx + 1}
-                </TabsTrigger>
+    <div
+      className={cn(
+        'flex min-h-screen text-white',
+        inter.className,
+      )}
+      style={{ backgroundColor: '#0E0E12' }}
+    >
+      <aside
+        className="w-[300px] flex flex-col p-6 space-y-6"
+        style={{ backgroundColor: '#15151A' }}
+      >
+        <div className="flex items-center gap-2 text-xl font-bold">
+          <span role="img" aria-label="wizard">🧙‍♂️</span>
+          <span>Wizzy</span>
+        </div>
+        <Button
+          type="button"
+          onClick={handleAddQuestion}
+          className="w-full bg-[#9147FF] hover:bg-[#A86EFF]"
+        >
+          + Add Question
+        </Button>
+        <div className="flex flex-col gap-2 overflow-y-auto pr-2">
+          {questions.map((q, idx) => (
+            <Button
+              key={q.id}
+              variant="ghost"
+              onClick={() => setTab(q.id)}
+              className={cn(
+                'justify-start',
+                'px-4',
+                tab === q.id
+                  ? 'border border-[#9147FF] bg-[#9147FF]/20 text-white'
+                  : 'bg-[#202026] text-[#C0C0C0] hover:bg-[#23232A]'
+              )}
+            >
+              Question {idx + 1}
+            </Button>
+          ))}
+        </div>
+      </aside>
+      <main className="flex-1 overflow-y-auto p-8 space-y-8">
+        <div
+          className="flex items-center justify-between rounded-lg p-6 shadow"
+          style={{ backgroundColor: '#15151A' }}
+        >
+          <h2 className="text-2xl font-semibold">{name || 'Quiz Name'}</h2>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost" size="icon" className="text-xl">
+                <Settings className="size-5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="p-0">
+              <Card className="bg-[#15151A] text-white border-none shadow">
+                <CardHeader>
+                  <CardTitle>Quiz Settings</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <Input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Quiz name"
+                    style={{ backgroundColor: '#202026', borderColor: '#2A2A33' }}
+                  />
+                  <textarea
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Description"
+                    rows={3}
+                    className="w-full rounded-md border px-3 py-2 text-sm"
+                    style={{ backgroundColor: '#202026', borderColor: '#2A2A33' }}
+                  />
+                  <div className="space-y-2">
+                    <input
+                      type="file"
+                      accept="application/json"
+                      onChange={(e) => handleImport(e.target.files?.[0] || null)}
+                    />
+                    <Button type="button" onClick={handleExport} className="w-full">
+                      Export
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </PopoverContent>
+          </Popover>
+        </div>
+        {questions.map((q, idx) => {
+          const audioEnabled = q.audioEnabled ?? Boolean(q.audioPromptKey || q.audioRevealKey)
+          if (q.id !== tab) return null
+          return (
+            <Card key={q.id} className="shadow" style={{ backgroundColor: '#15151A' }}>
+              <CardContent className="space-y-6">
+                <Input
+                  value={q.text}
+                  onChange={(e) => updateQuestionText(idx, e.target.value)}
+                  placeholder="Question text"
+                  style={{ backgroundColor: '#202026', borderColor: '#2A2A33' }}
+                />
+                <label className="flex items-center gap-3 text-[#C0C0C0]">
+                  <Switch
+                    checked={audioEnabled}
+                    onCheckedChange={(v) => toggleAudio(idx, v)}
+                    className="data-[state=checked]:bg-[#9147FF]"
+                  />
+                  Enable Sounds
+                </label>
+              {q.choices.map((c, cIdx) => (
+                <div key={c.id} className="flex items-center gap-3">
+                  <Input
+                    className="flex-1"
+                    style={{ backgroundColor: '#202026', borderColor: '#2A2A33' }}
+                    value={c.text}
+                    onChange={(e) => updateChoice(idx, cIdx, e.target.value)}
+                    placeholder={`Answer ${cIdx + 1}`}
+                  />
+                  <Button
+                    type="button"
+                    onClick={() => removeChoice(idx, cIdx)}
+                    variant="ghost"
+                    className="text-[#C0C0C0] hover:text-white"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
               ))}
-              <TabsTrigger value="add">+ Question</TabsTrigger>
-            </TabsList>
-
-            {questions.map((q, idx) => {
-              const audioEnabled = q.audioEnabled ?? Boolean(q.audioPromptKey || q.audioRevealKey)
-              return (
-                <TabsContent key={q.id} value={q.id} className="space-y-4">
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>Question {idx + 1}</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      <Input
-                        value={q.text}
-                        onChange={(e) => updateQuestionText(idx, e.target.value)}
-                        placeholder="Question text"
-                      />
-                      {q.choices.map((c, cIdx) => (
-                        <div key={c.id} className="flex items-center gap-2">
-                          <Input
-                            value={c.text}
-                            onChange={(e) =>
-                              updateChoice(idx, cIdx, e.target.value)
-                            }
-                            placeholder={`Choice ${cIdx + 1}`}
-                          />
-                          <Button
-                            type="button"
-                            variant="outline"
-                            onClick={() => removeChoice(idx, cIdx)}
-                          >
-                            Remove
-                          </Button>
-                        </div>
-                      ))}
-                      <Button
-                        type="button"
-                        onClick={() => addChoice(idx)}
-                        disabled={q.choices.length >= 4}
-                      >
-                        Add Choice
-                      </Button>
-
-                      <div className="flex items-center gap-2">
-                        <Switch
-                          checked={audioEnabled}
-                          onCheckedChange={(v) => toggleAudio(idx, v)}
-                        />
-                        <span className="text-sm">Add sound</span>
-                      </div>
-
-                      {audioEnabled && (
-                        <div className="flex flex-col gap-2">
-                          <FileDrop
-                            accept="audio/*"
-                            label={
-                              q.audioPromptKey
-                                ? `Question song: ${q.audioPromptKey}`
-                                : 'Question song'
-                            }
-                            playKey={q.audioPromptKey ?? undefined}
-                            onFile={(f) => handleAudio(idx, 'prompt', f)}
-                          />
-                          <FileDrop
-                            accept="audio/*"
-                            label={
-                              q.audioRevealKey
-                                ? `Reveal song: ${q.audioRevealKey}`
-                                : 'Reveal song'
-                            }
-                            playKey={q.audioRevealKey ?? undefined}
-                            onFile={(f) => handleAudio(idx, 'reveal', f)}
-                          />
-                        </div>
-                      )}
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-              )
-            })}
-
-            <TabsContent value="add">
-              <Button type="button" onClick={handleAddQuestion}>
-                Add Question
+              <Button
+                type="button"
+                onClick={() => addChoice(idx)}
+                disabled={q.choices.length >= 4}
+                className="w-full bg-[#9147FF] hover:bg-[#A86EFF]"
+              >
+                + Add Answer
               </Button>
-            </TabsContent>
-          </Tabs>
-        </div>
-
-        <div className="flex flex-col gap-4 lg:w-1/3">
-          <Card>
-            <CardHeader>
-              <CardTitle>Quiz Details</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              <Input
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Quiz name"
-              />
-              <textarea
-                className="w-full rounded-md border p-2"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="Description"
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Import / Export</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              <input
-                type="file"
-                accept="application/json"
-                onChange={(e) =>
-                  handleImport(e.target.files?.[0] || null)
-                }
-              />
-              <Button type="button" onClick={handleExport}>
-                Export
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      {errors.length > 0 && (
-        <Card className="border-destructive">
-          <CardContent className="space-y-1 text-destructive">
+              {audioEnabled && (
+                <div className="space-y-2">
+                  <FileDrop
+                    accept="audio/*"
+                    label={
+                      q.audioPromptKey
+                        ? `Question audio: ${q.audioPromptKey}`
+                        : 'Question audio'
+                    }
+                    playKey={q.audioPromptKey ?? undefined}
+                    onFile={(f) => handleAudio(idx, 'prompt', f)}
+                  />
+                  <FileDrop
+                    accept="audio/*"
+                    label={
+                      q.audioRevealKey
+                        ? `Reveal audio: ${q.audioRevealKey}`
+                        : 'Reveal audio'
+                    }
+                    playKey={q.audioRevealKey ?? undefined}
+                    onFile={(f) => handleAudio(idx, 'reveal', f)}
+                  />
+                </div>
+              )}
+              </CardContent>
+            </Card>
+          )
+        })}
+        {errors.length > 0 && (
+          <div className="space-y-1 rounded-md border border-destructive p-4 text-destructive">
             {errors.map((e) => (
               <div key={e}>{e}</div>
             ))}
-          </CardContent>
-        </Card>
-      )}
-
-      <Button onClick={onSubmit}>Save Quiz</Button>
+          </div>
+        )}
+        <Button onClick={onSubmit} className="bg-[#9147FF] hover:bg-[#A86EFF]">
+          Save Quiz
+        </Button>
+      </main>
     </div>
   )
 }

--- a/web/components/ui/popover.tsx
+++ b/web/components/ui/popover.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface PopoverContextProps {
+  open: boolean
+  setOpen: (v: boolean) => void
+  triggerRef: React.RefObject<HTMLButtonElement>
+}
+
+const PopoverContext = React.createContext<PopoverContextProps | null>(null)
+
+function Popover({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+  const triggerRef = React.useRef<HTMLButtonElement>(null)
+  return (
+    <PopoverContext.Provider value={{ open, setOpen, triggerRef }}>
+      <div className="relative inline-block">{children}</div>
+    </PopoverContext.Provider>
+  )
+}
+
+const PopoverTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<"button">
+>(function PopoverTrigger({ children, ...props }, ref) {
+  const ctx = React.useContext(PopoverContext)
+  if (!ctx) throw new Error("PopoverTrigger must be within Popover")
+  return (
+    <button
+      ref={(node) => {
+        ctx.triggerRef.current = node
+        if (typeof ref === "function") ref(node)
+        else if (ref) (ref as React.MutableRefObject<HTMLButtonElement | null>).current = node
+      }}
+      onClick={() => ctx.setOpen(!ctx.open)}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+})
+
+const PopoverContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentPropsWithoutRef<"div"> & { align?: "start" | "center" | "end" }
+>(function PopoverContent({ className, align = "center", ...props }, ref) {
+  const ctx = React.useContext(PopoverContext)
+  if (!ctx) throw new Error("PopoverContent must be within Popover")
+  const [styles, setStyles] = React.useState<React.CSSProperties>({})
+  React.useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (
+        ctx.triggerRef.current &&
+        !ctx.triggerRef.current.contains(e.target as Node) &&
+        !(ref && (ref as React.MutableRefObject<HTMLDivElement | null>).current?.contains(e.target as Node))
+      ) {
+        ctx.setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClick)
+    const rect = ctx.triggerRef.current?.getBoundingClientRect()
+    if (rect) {
+      let left = rect.left
+      if (align === "center") left = rect.left + rect.width / 2
+      if (align === "end") left = rect.right
+      setStyles({ position: "absolute", top: rect.bottom + 4, left })
+    }
+    return () => document.removeEventListener("mousedown", handleClick)
+  }, [ctx, align, ref])
+  if (!ctx.open) return null
+  return (
+    <div
+      ref={ref}
+      style={styles}
+      className={cn(
+        "z-50 w-72 -translate-x-1/2 rounded-md border bg-popover p-4 text-popover-foreground shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  )
+})
+
+export { Popover, PopoverTrigger, PopoverContent }


### PR DESCRIPTION
## Summary
- redesign quiz form with dark themed sidebar layout
- add Inter font usage and allow editing quiz name
- use shadcn inputs/cards and popover settings menu
- restore import/export logic inside cog popover

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web build` *(fails: Failed to fetch fonts)*


------
https://chatgpt.com/codex/tasks/task_e_68613752e6648323aee00f8c51576f5e