### PR TITLE
Fix popover and restore await usage

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -43,8 +43,8 @@ export default async function RootLayout({
 
   return (
     <html lang="en" className="dark">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased pt-20`}>
-        <header className="fixed top-0 left-0 z-50 w-full bg-gradient-to-b from-black/70 to-transparent">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <header className="w-full bg-gradient-to-b from-black/70 to-transparent">
           <div className="max-w-screen-xl mx-auto flex items-center justify-between py-6 px-8">
             <Link href="/" className="flex items-center gap-2 font-bold text-white">
               <span role="img" aria-label="wizard">🧙‍♂️</span>

--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -133,7 +133,7 @@ export default function QuizForm({ quiz }: { quiz: QuizPayload & { id: string } 
         }))
       )
       toast.success('Imported quiz')
-    } catch (e) {
+    } catch {
       toast.error('Failed to import')
     }
   }
@@ -142,8 +142,8 @@ export default function QuizForm({ quiz }: { quiz: QuizPayload & { id: string } 
     exportQuiz({
       name,
       description,
-      questions: questions.map((q) => {
-        const { audioEnabled: _, ...rest } = q
+      questions: questions.map(({ audioEnabled, ...rest }) => {
+        void audioEnabled
         return rest
       }),
     })
@@ -154,8 +154,8 @@ export default function QuizForm({ quiz }: { quiz: QuizPayload & { id: string } 
     const payload = {
       name,
       description,
-      questions: questions.map((q) => {
-        const { audioEnabled: _, ...rest } = q
+      questions: questions.map(({ audioEnabled, ...rest }) => {
+        void audioEnabled
         return rest
       }),
     }

--- a/web/components/ui/popover.tsx
+++ b/web/components/ui/popover.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
 import { cn } from "@/lib/utils"
 
 interface PopoverContextProps {
@@ -23,13 +24,14 @@ function Popover({ children }: { children: React.ReactNode }) {
 
 const PopoverTrigger = React.forwardRef<
   HTMLButtonElement,
-  React.ComponentPropsWithoutRef<"button">
->(function PopoverTrigger({ children, ...props }, ref) {
+  React.ComponentPropsWithoutRef<"button"> & { asChild?: boolean }
+>(function PopoverTrigger({ children, asChild = false, ...props }, ref) {
   const ctx = React.useContext(PopoverContext)
   if (!ctx) throw new Error("PopoverTrigger must be within Popover")
+  const Comp = asChild ? Slot : "button"
   return (
-    <button
-      ref={(node) => {
+    <Comp
+      ref={(node: HTMLButtonElement | null) => {
         ctx.triggerRef.current = node
         if (typeof ref === "function") ref(node)
         else if (ref) (ref as React.MutableRefObject<HTMLButtonElement | null>).current = node
@@ -38,7 +40,7 @@ const PopoverTrigger = React.forwardRef<
       {...props}
     >
       {children}
-    </button>
+    </Comp>
   )
 })
 


### PR DESCRIPTION
## Summary
- allow popover trigger to render as child element
- use normal scrolling header again
- clean up quiz form imports and exports
- keep await usage on route params

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web build` *(fails: Failed to fetch fonts)*
- `pnpm --filter server test`
- `pnpm --filter server build`


------
https://chatgpt.com/codex/tasks/task_e_68616a96cff4832396b3e42b791831b2