### PR TITLE
Style import input like file drop

### DIFF
--- a/web/components/quiz-form.tsx
+++ b/web/components/quiz-form.tsx
@@ -9,6 +9,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { FileDrop } from "@/components/ui/file-drop";
+import { FileInput } from "@/components/ui/file-input";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/sonner";
 import { Switch } from "@/components/ui/switch";
@@ -267,13 +268,10 @@ export default function QuizForm({
                     }}
                   />
                   <div className="flex items-center gap-2">
-                    <Input
-                      type="file"
+                    <FileInput
                       accept="application/json"
-                      onChange={(e) => {
-                        handleImport(e.target.files?.[0] || null);
-                        e.target.value = "";
-                      }}
+                      onFile={handleImport}
+                      label="Import Quiz"
                       className="flex-1 bg-[#202026] border-[#2A2A33]"
                     />
                     <Button

--- a/web/components/ui/file-input.tsx
+++ b/web/components/ui/file-input.tsx
@@ -1,0 +1,33 @@
+"use client"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface FileInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "onChange"> {
+  onFile: (file: File | null) => void
+  label?: React.ReactNode
+}
+
+export function FileInput({ onFile, label = "Drop or click", className, accept, ...props }: FileInputProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onFile(e.target.files?.[0] || null)
+    e.target.value = ""
+  }
+  const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault()
+    onFile(e.dataTransfer.files?.[0] || null)
+  }
+  return (
+    <label
+      onDrop={handleDrop}
+      onDragOver={(e) => e.preventDefault()}
+      className={cn(
+        "relative flex h-24 cursor-pointer items-center justify-center rounded-md border border-dashed p-2 text-sm bg-[#202026] border-[#2A2A33]",
+        className,
+      )}
+    >
+      <input type="file" accept={accept} onChange={handleChange} className="hidden" {...props} />
+      {label}
+    </label>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add a `FileInput` component styled like `FileDrop`
- use `FileInput` for quiz import

## Testing
- `pnpm --filter web lint`

------
https://chatgpt.com/codex/tasks/task_e_6861be03de748323a144eccbc2af1e11