### PR TITLE
Redesign dashboard with card list and setup form

### DIFF
--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -3,6 +3,9 @@ import { getCurrentUser } from '@/lib/auth'
 import Link from 'next/link'
 import ErrorScreen from '@/components/error-screen'
 import { tryWithError } from '@/lib/try-with-error'
+import StartQuizForm from '@/components/start-quiz-form'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 
 export default async function DashboardPage() {
   const [user, userError] = await tryWithError(() => getCurrentUser())
@@ -15,16 +18,32 @@ export default async function DashboardPage() {
   if (quizError) return <ErrorScreen title="Database Unreachable" />
 
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Your Quizzes</h1>
-      <Link className="underline" href="/dashboard/quiz/new">Create New Quiz</Link>
-      <ul className="mt-4 space-y-2">
-        {quizzes.map((q) => (
-          <li key={q.id}>
-            <Link className="text-purple-600 underline" href={`/dashboard/quiz/${q.id}`}>{q.name}</Link>
-          </li>
-        ))}
-      </ul>
+    <main className="p-8 mx-auto max-w-4xl">
+      <div className="grid gap-8 md:grid-cols-2">
+        <section>
+          <h1 className="text-xl font-bold tracking-tight mb-4">Your Quizzes</h1>
+          <Button asChild className="mb-4">
+            <Link href="/dashboard/quiz/new">Create New Quiz</Link>
+          </Button>
+          <ul className="space-y-3">
+            {quizzes.map((q) => (
+              <li key={q.id}>
+                <Card className="hover:bg-muted/50 transition-colors">
+                  <CardContent className="p-4">
+                    <Link href={`/dashboard/quiz/${q.id}`} className="font-medium">
+                      {q.name}
+                    </Link>
+                  </CardContent>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h2 className="text-xl font-bold tracking-tight mb-4">Create Room</h2>
+          <StartQuizForm quizzes={quizzes} />
+        </section>
+      </div>
     </main>
   );
 }

--- a/web/components/start-quiz-form.tsx
+++ b/web/components/start-quiz-form.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+
+interface Props {
+  quizzes: { id: string; name: string }[]
+}
+
+export default function StartQuizForm({ quizzes }: Props) {
+  const [roomName, setRoomName] = useState("")
+  const [quizId, setQuizId] = useState(quizzes[0]?.id ?? "")
+  const [visibility, setVisibility] = useState<"open" | "followers" | "subs">(
+    "open"
+  )
+
+  return (
+    <div className="space-y-4">
+      <Input
+        placeholder="Room Name"
+        value={roomName}
+        onChange={(e) => setRoomName(e.target.value)}
+      />
+      <Select value={quizId} onValueChange={setQuizId}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select Quiz" />
+        </SelectTrigger>
+        <SelectContent>
+          {quizzes.map((q) => (
+            <SelectItem key={q.id} value={q.id}>
+              {q.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <div className="flex justify-center">
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          value={visibility}
+          onValueChange={(v: string) => {
+            if (v) setVisibility(v as "open" | "followers" | "subs")
+          }}
+        >
+          <ToggleGroupItem value="open">Open</ToggleGroupItem>
+          <ToggleGroupItem value="followers">Followers</ToggleGroupItem>
+          <ToggleGroupItem value="subs">Subs</ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      <div className="pt-4 flex justify-center">
+        <Button className="w-full max-w-xs">Start Quiz</Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- improve dashboard layout and style
- add new `StartQuizForm` client component for room setup
- display quizzes as cards with hover effects and create room form

## Testing
- `pnpm --filter web lint`

------
https://chatgpt.com/codex/tasks/task_e_6861dfaf01c883239e0ea38cc880b965