### PR TITLE
Add countdown support in lobby flow

### DIFF
--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -33,6 +33,7 @@ export interface LobbyState {
   answers: Map<string, Map<string, number>>;
   questionStartedAt?: number;
   questionTimer?: NodeJS.Timeout;
+  countdownTimer?: NodeJS.Timeout;
   reconnectTimer?: NodeJS.Timeout;
 }
 

--- a/server/test/server.test.ts
+++ b/server/test/server.test.ts
@@ -36,7 +36,7 @@ vi.mock("../src/lib/prisma", () => {
   };
 });
 
-const testEnv = { NODE_ENV: "development" };
+const testEnv = { NODE_ENV: "development", QUIZ_COUNTDOWN_MS: "0" };
 
 describe("socket server", () => {
   let httpServer: ReturnType<typeof createApp>["httpServer"];

--- a/server/test/socket.flows.test.ts
+++ b/server/test/socket.flows.test.ts
@@ -53,7 +53,7 @@ vi.mock("../src/lib/prisma", () => {
   };
 });
 
-const testEnv = { NODE_ENV: "development" };
+const testEnv = { NODE_ENV: "development", QUIZ_COUNTDOWN_MS: "0" };
 
 function once<T>(socket: any, event: string) {
   return new Promise<T>((resolve) => socket.once(event, resolve));

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -66,6 +66,10 @@ export type SocketEventDefinition = {
     direction: "web->server";
     payload: StartQuestionPayload;
   };
+  question_countdown: {
+    direction: "server->viewer" | "server->web";
+    payload: { duration: number };
+  };
   question_started: {
     direction: "server->viewer";
     payload: QuestionStartedPayload;
@@ -140,6 +144,9 @@ export interface LobbyFullPayload {
 
 export interface StartQuestionPayload {
   lobbyId: string;
+}
+export interface QuestionCountdownPayload {
+  duration: number;
 }
 export interface QuestionStartedPayload {
   id: string;


### PR DESCRIPTION
## Summary
- enhance shared types with `question_countdown`
- send join info to streamer and add countdown logic in socket
- track countdown timer and participants in live dashboard
- adjust tests to disable countdown

## Testing
- `pnpm --filter server test`

------
https://chatgpt.com/codex/tasks/task_e_6861fe8fab4083239fc92b2e595c41f3